### PR TITLE
Модернизация обработки спецсимволом MarkDown в именах пользователей

### DIFF
--- a/awg/bot_manager.py
+++ b/awg/bot_manager.py
@@ -53,7 +53,7 @@ ENDPOINT = None
 
 def escape_markdown_v2(text: str) -> str:
     """
-    Экранирует все спецсимволы для Telegram MarkdownV2.
+    Экранирует все спецсимволы для Telegram MarkDownV2.
     Список из оф. доки Telegram Bot API:
     _ * [ ] ( ) ~ ` > # + - = | { } . !
     """
@@ -480,7 +480,7 @@ async def handle_messages(message: types.Message):
                 chat_id=main_chat_id,
                 message_id=main_message_id,
                 text=f"Выберите время действия конфигурации для пользователя **{user_name}**:",
-                parse_mode="Markdown",
+                parse_mode="MarkDown",
                 reply_markup=duration_markup
             )
         else:
@@ -548,7 +548,7 @@ async def set_config_duration(callback: types.CallbackQuery):
         chat_id=callback.message.chat.id,
         message_id=callback.message.message_id,
         text=f"Выберите лимит трафика для пользователя **{client_name}**:",
-        parse_mode="Markdown",
+        parse_mode="MarkDown",
         reply_markup=traffic_markup
     )
     await callback.answer()
@@ -631,27 +631,27 @@ async def set_traffic_limit(callback_query: types.CallbackQuery):
                         admin,
                         config,
                         caption=caption,
-                        parse_mode="Markdown",
+                        parse_mode="MarDdown",
                         disable_notification=True
                     )
                     asyncio.create_task(delete_message_after_delay(admin, sent_doc.message_id, delay=15))
         except FileNotFoundError:
             confirmation_text = "Не удалось найти файлы конфигурации для указанного пользователя."
-            sent_message = await bot.send_message(admin, confirmation_text, parse_mode="Markdown", disable_notification=True)
+            sent_message = await bot.send_message(admin, confirmation_text, parse_mode="MarkDown", disable_notification=True)
             asyncio.create_task(delete_message_after_delay(admin, sent_message.message_id, delay=15))
             await callback_query.answer()
             return
         except Exception as e:
             logger.error(f"Ошибка при отправке конфигурации: {e}")
             confirmation_text = "Произошла ошибка."
-            sent_message = await bot.send_message(admin, confirmation_text, parse_mode="Markdown", disable_notification=True)
+            sent_message = await bot.send_message(admin, confirmation_text, parse_mode="MarkDown", disable_notification=True)
             asyncio.create_task(delete_message_after_delay(admin, sent_message.message_id, delay=15))
             await callback_query.answer()
             return
         sent_confirmation = await bot.send_message(
             chat_id=admin,
             text=confirmation_text,
-            parse_mode="Markdown",
+            parse_mode="MarkDown",
             disable_notification=True
         )
         asyncio.create_task(delete_message_after_delay(admin, sent_confirmation.message_id, delay=15))
@@ -660,7 +660,7 @@ async def set_traffic_limit(callback_query: types.CallbackQuery):
         sent_confirmation = await bot.send_message(
             chat_id=admin,
             text=confirmation_text,
-            parse_mode="Markdown",
+            parse_mode="MarkDown",
             disable_notification=True
         )
         asyncio.create_task(delete_message_after_delay(admin, sent_confirmation.message_id, delay=15))
@@ -819,7 +819,7 @@ async def client_selected_callback(callback_query: types.CallbackQuery):
                 chat_id=main_chat_id,
                 message_id=main_message_id,
                 text=text,
-                parse_mode="Markdown",
+                parse_mode="MarkDown",
                 reply_markup=keyboard
             )
         except Exception as e:
@@ -1032,7 +1032,7 @@ async def ip_info_callback(callback_query: types.CallbackQuery):
         logger.error(f"Ошибка при запросе к API: {e}")
         await callback_query.answer("Ошибка при запросе к API.", show_alert=True)
         return
-    info_text = f"*IP информация для {escape_markdown_v2(username)}:*\n"
+    info_text = f"*IP информация для {username}:*\n"
     for key, value in data.items():
         info_text += f"{key.capitalize()}: {value}\n"
     keyboard = InlineKeyboardMarkup(row_width=2)
@@ -1048,7 +1048,7 @@ async def ip_info_callback(callback_query: types.CallbackQuery):
                 chat_id=main_chat_id,
                 message_id=main_message_id,
                 text=info_text,
-                parse_mode="Markdown",
+                parse_mode="MarkDown",
                 reply_markup=keyboard
             )
         except Exception as e:
@@ -1076,8 +1076,8 @@ async def confirm_delete_user_callback(callback_query: types.CallbackQuery):
     await bot.edit_message_text(
         chat_id=callback_query.message.chat.id,
         message_id=callback_query.message.message_id,
-        text=f"⚠️ Вы уверены, что хотите удалить пользователя *{escape_markdown_v2(username)}*?\n\nЭто действие нельзя отменить!",
-        parse_mode="Markdown",
+        text=f"⚠️ Вы уверены, что хотите удалить пользователя *{username}*?\n\nЭто действие нельзя отменить!",
+        parse_mode="MarkDown",
         reply_markup=keyboard
     )
     await callback_query.answer()
@@ -1113,9 +1113,9 @@ async def client_delete_callback(callback_query: types.CallbackQuery):
                 os.remove(connections_file)
         except Exception as e:
             logger.error(f"Ошибка при удалении файла подключений для пользователя {username}: {e}")
-        confirmation_text = f"Пользователь **{escape_markdown_v2(username)}** успешно удален."
+        confirmation_text = f"Пользователь **{username}** успешно удален."
     else:
-        confirmation_text = f"Не удалось удалить пользователя **{escape_markdown_v2(username)}**."
+        confirmation_text = f"Не удалось удалить пользователя **{username}**."
     main_chat_id = user_main_messages.get(admin, {}).get('chat_id')
     main_message_id = user_main_messages.get(admin, {}).get('message_id')
     if main_chat_id and main_message_id:
@@ -1123,7 +1123,7 @@ async def client_delete_callback(callback_query: types.CallbackQuery):
             chat_id=main_chat_id,
             message_id=main_message_id,
             text=confirmation_text,
-            parse_mode="Markdown",
+            parse_mode="MarkDown",
             reply_markup=main_menu_markup
         )
     else:
@@ -1227,7 +1227,7 @@ async def delete_server_callback(callback_query: types.CallbackQuery):
         chat_id=callback_query.message.chat.id,
         message_id=callback_query.message.message_id,
         text="Выберите сервер для удаления.\n\n*ВНИМАНИЕ*: При удалении сервера будут удалены все его пользователи и конфигурации!",
-        parse_mode="Markdown",
+        parse_mode="MarkDown",
         reply_markup=keyboard
     )
     await callback_query.answer()
@@ -1249,7 +1249,7 @@ async def confirm_delete_server_callback(callback_query: types.CallbackQuery):
         chat_id=callback_query.message.chat.id,
         message_id=callback_query.message.message_id,
         text=f"⚠️ Вы уверены, что хотите удалить сервер *{server_id}*?\n\nЭто действие нельзя отменить!",
-        parse_mode="Markdown",
+        parse_mode="MarkDown",
         reply_markup=keyboard
     )
     await callback_query.answer()
@@ -1370,34 +1370,34 @@ async def send_user_config(callback_query: types.CallbackQuery):
                     admin,
                     config,
                     caption=caption,
-                    parse_mode="Markdown",
+                    parse_mode="MarkDown",
                     disable_notification=True
                 )
                 sent_messages.append(sent_doc.message_id)
         else:
-            confirmation_text = f"Не удалось создать конфигурацию для пользователя **{escape_markdown_v2(username)}**."
-            sent_message = await bot.send_message(admin, confirmation_text, parse_mode="Markdown", disable_notification=True)
+            confirmation_text = f"Не удалось создать конфигурацию для пользователя **{username}**."
+            sent_message = await bot.send_message(admin, confirmation_text, parse_mode="MarkDown", disable_notification=True)
             asyncio.create_task(delete_message_after_delay(admin, sent_message.message_id, delay=15))
             await callback_query.answer()
             return
     except Exception as e:
         confirmation_text = f"Произошла ошибка: {e}"
-        sent_message = await bot.send_message(admin, confirmation_text, parse_mode="Markdown", disable_notification=True)
+        sent_message = await bot.send_message(admin, confirmation_text, parse_mode="MarkDown", disable_notification=True)
         asyncio.create_task(delete_message_after_delay(admin, sent_message.message_id, delay=15))
         await callback_query.answer()
         return
     if not sent_messages:
-        confirmation_text = f"Не удалось найти файлы конфигурации для пользователя **{escape_markdown_v2(username)}**."
-        sent_message = await bot.send_message(admin, confirmation_text, parse_mode="Markdown", disable_notification=True)
+        confirmation_text = f"Не удалось найти файлы конфигурации для пользователя **{username}**."
+        sent_message = await bot.send_message(admin, confirmation_text, parse_mode="MarkDown", disable_notification=True)
         asyncio.create_task(delete_message_after_delay(admin, sent_message.message_id, delay=15))
         await callback_query.answer()
         return
     else:
-        confirmation_text = f"Конфигурация для **{escape_markdown_v2(username)}** отправлена."
+        confirmation_text = f"Конфигурация для **{username}** отправлена."
         sent_confirmation = await bot.send_message(
             chat_id=admin,
             text=confirmation_text,
-            parse_mode="Markdown",
+            parse_mode="MarkDown",
             disable_notification=True
         )
         asyncio.create_task(delete_message_after_delay(admin, sent_confirmation.message_id, delay=15))
@@ -1512,7 +1512,7 @@ async def send_user_config(callback_query: types.CallbackQuery):
                 chat_id=callback_query.message.chat.id,
                 message_id=callback_query.message.message_id,
                 text=text,
-                parse_mode="Markdown",
+                parse_mode="MarkDown",
                 reply_markup=keyboard
             )
         except aiogram_exceptions.MessageNotModified:
@@ -1618,7 +1618,7 @@ async def read_traffic(username, server_id='default'):
                 traffic_data = json.loads(content)
                 return traffic_data
             except json.JSONDecodeError:
-                logger.error(f"Ошибка при чтении traffic.json для пользователя {escape_markdown_v2(username)}. Инициализация заново.")
+                logger.error(f"Ошибка при чтении traffic.json для пользователя {username}. Инициализация заново.")
                 traffic_data = {
                     "total_incoming": 0,
                     "total_outgoing": 0,
@@ -1658,7 +1658,7 @@ async def update_all_clients_traffic():
         transfer = client.get('transfer', '0/0')
         incoming_bytes, outgoing_bytes = parse_transfer(transfer)
         traffic_data = await update_traffic(username, incoming_bytes, outgoing_bytes, current_server)
-        logger.info(f"Обновлён трафик для пользователя {escape_markdown_v2(username)}: Входящий {traffic_data['total_incoming']} B, Исходящий {traffic_data['total_outgoing']} B")
+        logger.info(f"Обновлён трафик для пользователя {username}: Входящий {traffic_data['total_incoming']} B, Исходящий {traffic_data['total_outgoing']} B")
         traffic_limit = db.get_user_traffic_limit(username, server_id=current_server)
         if traffic_limit != "Неограниченно":
             limit_bytes = parse_traffic_limit(traffic_limit)
@@ -1713,10 +1713,10 @@ async def deactivate_user(client_name: str):
         except Exception as e:
             logger.error(f"Ошибка при удалении файла подключений для пользователя {client_name}: {e}")
         confirmation_text = f"Конфигурация пользователя **{client_name}** была деактивирована из-за превышения лимита трафика."
-        sent_message = await bot.send_message(admin, confirmation_text, parse_mode="Markdown", disable_notification=True)
+        sent_message = await bot.send_message(admin, confirmation_text, parse_mode="MarkDown", disable_notification=True)
         asyncio.create_task(delete_message_after_delay(admin, sent_message.message_id, delay=15))
     else:
-        sent_message = await bot.send_message(admin, f"Не удалось деактивировать пользователя **{client_name}**.", parse_mode="Markdown", disable_notification=True)
+        sent_message = await bot.send_message(admin, f"Не удалось деактивировать пользователя **{client_name}**.", parse_mode="MarkDown", disable_notification=True)
         asyncio.create_task(delete_message_after_delay(admin, sent_message.message_id, delay=15))
 
 async def check_environment():

--- a/awg/bot_manager.py
+++ b/awg/bot_manager.py
@@ -51,6 +51,15 @@ WG_CONFIG_FILE = None
 DOCKER_CONTAINER = None
 ENDPOINT = None
 
+def escape_markdown_v2(text: str) -> str:
+    """
+    Экранирует все спецсимволы для Telegram MarkdownV2.
+    Список из оф. доки Telegram Bot API:
+    _ * [ ] ( ) ~ ` > # + - = | { } . !
+    """
+    escape_chars = r"_*[]()~`>#+-=|{}.!"
+    return "".join("\\" + c if c in escape_chars else c for c in text)
+
 def update_server_settings(server_id=None):
     global current_server, WG_CONFIG_FILE, DOCKER_CONTAINER, ENDPOINT
     if server_id:
@@ -774,9 +783,9 @@ async def client_selected_callback(callback_query: types.CallbackQuery):
     else:
         show_last_handshake = "❗Нет данных❗"
 
-    username = username.replace('_', ' ')
+    
     text = (
-        f"📧 _Имя:_ {username}\n"
+        f"📧 _Имя:_ {escape_markdown_v2(username)}\n"
         f"🌐 _Внутренний IPv4:_ {ipv4_address}\n"
         f"🌐 _Статус соединения:_ {status}\n"
         f"⏳ _Последнее 🤝:_ {show_last_handshake}\n"

--- a/awg/bot_manager.py
+++ b/awg/bot_manager.py
@@ -1032,7 +1032,7 @@ async def ip_info_callback(callback_query: types.CallbackQuery):
         logger.error(f"Ошибка при запросе к API: {e}")
         await callback_query.answer("Ошибка при запросе к API.", show_alert=True)
         return
-    info_text = f"*IP информация для {username}:*\n"
+    info_text = f"*IP информация для {escape_markdown_v2(username)}:*\n"
     for key, value in data.items():
         info_text += f"{key.capitalize()}: {value}\n"
     keyboard = InlineKeyboardMarkup(row_width=2)
@@ -1076,7 +1076,7 @@ async def confirm_delete_user_callback(callback_query: types.CallbackQuery):
     await bot.edit_message_text(
         chat_id=callback_query.message.chat.id,
         message_id=callback_query.message.message_id,
-        text=f"⚠️ Вы уверены, что хотите удалить пользователя *{username}*?\n\nЭто действие нельзя отменить!",
+        text=f"⚠️ Вы уверены, что хотите удалить пользователя *{escape_markdown_v2(username)}*?\n\nЭто действие нельзя отменить!",
         parse_mode="Markdown",
         reply_markup=keyboard
     )
@@ -1113,9 +1113,9 @@ async def client_delete_callback(callback_query: types.CallbackQuery):
                 os.remove(connections_file)
         except Exception as e:
             logger.error(f"Ошибка при удалении файла подключений для пользователя {username}: {e}")
-        confirmation_text = f"Пользователь **{username}** успешно удален."
+        confirmation_text = f"Пользователь **{escape_markdown_v2(username)}** успешно удален."
     else:
-        confirmation_text = f"Не удалось удалить пользователя **{username}**."
+        confirmation_text = f"Не удалось удалить пользователя **{escape_markdown_v2(username)}**."
     main_chat_id = user_main_messages.get(admin, {}).get('chat_id')
     main_message_id = user_main_messages.get(admin, {}).get('message_id')
     if main_chat_id and main_message_id:
@@ -1375,7 +1375,7 @@ async def send_user_config(callback_query: types.CallbackQuery):
                 )
                 sent_messages.append(sent_doc.message_id)
         else:
-            confirmation_text = f"Не удалось создать конфигурацию для пользователя **{username}**."
+            confirmation_text = f"Не удалось создать конфигурацию для пользователя **{escape_markdown_v2(username)}**."
             sent_message = await bot.send_message(admin, confirmation_text, parse_mode="Markdown", disable_notification=True)
             asyncio.create_task(delete_message_after_delay(admin, sent_message.message_id, delay=15))
             await callback_query.answer()
@@ -1387,13 +1387,13 @@ async def send_user_config(callback_query: types.CallbackQuery):
         await callback_query.answer()
         return
     if not sent_messages:
-        confirmation_text = f"Не удалось найти файлы конфигурации для пользователя **{username}**."
+        confirmation_text = f"Не удалось найти файлы конфигурации для пользователя **{escape_markdown_v2(username)}**."
         sent_message = await bot.send_message(admin, confirmation_text, parse_mode="Markdown", disable_notification=True)
         asyncio.create_task(delete_message_after_delay(admin, sent_message.message_id, delay=15))
         await callback_query.answer()
         return
     else:
-        confirmation_text = f"Конфигурация для **{username}** отправлена."
+        confirmation_text = f"Конфигурация для **{escape_markdown_v2(username)}** отправлена."
         sent_confirmation = await bot.send_message(
             chat_id=admin,
             text=confirmation_text,
@@ -1481,7 +1481,7 @@ async def send_user_config(callback_query: types.CallbackQuery):
             show_last_handshake = "❗Нет данных❗"
 
         text = (
-            f"📧 _Имя:_ {username}\n"
+            f"📧 _Имя:_ {escape_markdown_v2(username)}\n"
             f"🌐 _Внутренний IPv4:_ {ipv4_address}\n"
             f"🌐 _Статус соединения:_ {status}\n"
             f"🔼 _Исходящий трафик:_ {incoming_traffic}\n"
@@ -1618,7 +1618,7 @@ async def read_traffic(username, server_id='default'):
                 traffic_data = json.loads(content)
                 return traffic_data
             except json.JSONDecodeError:
-                logger.error(f"Ошибка при чтении traffic.json для пользователя {username}. Инициализация заново.")
+                logger.error(f"Ошибка при чтении traffic.json для пользователя {escape_markdown_v2(username)}. Инициализация заново.")
                 traffic_data = {
                     "total_incoming": 0,
                     "total_outgoing": 0,
@@ -1658,7 +1658,7 @@ async def update_all_clients_traffic():
         transfer = client.get('transfer', '0/0')
         incoming_bytes, outgoing_bytes = parse_transfer(transfer)
         traffic_data = await update_traffic(username, incoming_bytes, outgoing_bytes, current_server)
-        logger.info(f"Обновлён трафик для пользователя {username}: Входящий {traffic_data['total_incoming']} B, Исходящий {traffic_data['total_outgoing']} B")
+        logger.info(f"Обновлён трафик для пользователя {escape_markdown_v2(username)}: Входящий {traffic_data['total_incoming']} B, Исходящий {traffic_data['total_outgoing']} B")
         traffic_limit = db.get_user_traffic_limit(username, server_id=current_server)
         if traffic_limit != "Неограниченно":
             limit_bytes = parse_traffic_limit(traffic_limit)


### PR DESCRIPTION
Предыдущий вариант был немножко костыльным, по факту, поэтом тут добавил полноценную функцию, которая экранирует спецсимволы MarkDown, чтобы они нормально проходили как текст.